### PR TITLE
fix: redirect restful-client -> restful-client/GET

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,10 +1,25 @@
+import { DEFAULT_HTTP_METHOD } from '@/types';
+import { RESTFUL_CLIENT } from '@/types/routes';
+import { LOCALES } from '@/utils/constants';
 import type { NextConfig } from 'next';
 import createNextIntlPlugin from 'next-intl/plugin';
 
 const withNextIntl = createNextIntlPlugin();
 
+const restfulClientRedirects = LOCALES.map((locale) => {
+  const sourceRoute = `/${locale}/${RESTFUL_CLIENT}`;
+
+  return {
+    source: sourceRoute,
+    destination: `${sourceRoute}/${DEFAULT_HTTP_METHOD}`,
+    permanent: true,
+  };
+});
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  async redirects() {
+    return restfulClientRedirects;
+  },
 };
 
 export default withNextIntl(nextConfig);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,6 +33,8 @@ export const HTTP_METHODS = [
 
 export type HttpMethod = (typeof HTTP_METHODS)[number];
 
+export const DEFAULT_HTTP_METHOD: HttpMethod = 'GET';
+
 export type ResponseData = {
   status: number;
   headers: { key: string; value: string }[];

--- a/src/types/routes.ts
+++ b/src/types/routes.ts
@@ -15,7 +15,7 @@ export const Routes = {
     encodedBody?: string,
     headers?: Record<string, string>
   ) => {
-    let path = `/restful-client/${method}/${encodedUrl}`;
+    let path = `/${RESTFUL_CLIENT}/${method}/${encodedUrl}`;
     if (encodedBody) {
       path += `/${encodedBody}`;
     }


### PR DESCRIPTION
1. Task:
2. Type of change:

- [ ] Feature
- [x] Bugfix
- [ ] Refactoring
- [ ] Styling
- [ ] Documentation
- [ ] Tests
- [ ] Project settings / configs

3. Description: restful-client route was showing a 404 page, it will redirect to the restful-client/GET page now
4. Screenshot:
